### PR TITLE
Add unit tests for core packages

### DIFF
--- a/ros2_ws/src/hri_audio/hri_audio/tests/test_hotword.py
+++ b/ros2_ws/src/hri_audio/hri_audio/tests/test_hotword.py
@@ -1,0 +1,36 @@
+import numpy as np
+from unittest.mock import Mock, patch
+
+from hri_audio.utils.stt_hotword import STTHotword
+
+# Black-box: validate _check_hotword identifies name regardless of formatting
+
+def test_check_hotword_positive():
+    hotword = STTHotword(lambda *args, **kwargs: "")
+    assert hotword._check_hotword("Hola Sancho") is True
+
+
+def test_check_hotword_negative():
+    hotword = STTHotword(lambda *args, **kwargs: "")
+    assert hotword._check_hotword("Hello robot") is False
+
+
+# White-box: ensure _transcribe handles exceptions and returns empty string
+
+def test_transcribe_handles_exception():
+    stt_fn = Mock(side_effect=Exception("fail"))
+    hotword = STTHotword(stt_fn)
+    result = hotword._transcribe(np.array([1, 2], dtype=np.int16), 16000)
+    assert result == ""
+
+
+# Hybrid: detect should call _transcribe and _check_hotword when buffer exceeds limit
+
+def test_detect_calls_transcribe_and_check():
+    stt_fn = Mock(return_value="")
+    hotword = STTHotword(stt_fn, max_seconds=0.1)
+    with patch.object(STTHotword, "_transcribe", return_value="test") as trans_mock, \
+         patch.object(STTHotword, "_check_hotword", return_value=False) as check_mock:
+        hotword.detect([0] * 1600, 16000)  # 0.1s of audio
+        trans_mock.assert_called_once()
+        check_mock.assert_called_once_with("test")

--- a/ros2_ws/src/hri_vision/hri_vision/tests/test_faceprints_database.py
+++ b/ros2_ws/src/hri_vision/hri_vision/tests/test_faceprints_database.py
@@ -1,0 +1,38 @@
+from hri_vision.database.faceprints_database import FaceprintsDatabase
+
+# Black-box: verify add and get operations work without saving
+
+def test_add_and_get_faceprint():
+    db = FaceprintsDatabase(db_path="unused.json", db_mode="no_save")
+    entry = db.add("Alice", [1.0], "img", 0.9)
+    assert db.get_by_id(entry["id"]) == entry
+    assert entry["name"] == "Alice"
+
+
+# White-box: update modifies stored data
+
+def test_update_faceprint():
+    db = FaceprintsDatabase(db_path="unused.json", db_mode="no_save")
+    entry = db.add("Bob", [1.0], "img", 0.9)
+    db.update(entry["id"], {"name": "Robert"})
+    assert db.get_by_id(entry["id"])["name"] == "Robert"
+
+
+# White-box: removing deletes entry
+
+def test_remove_faceprint():
+    db = FaceprintsDatabase(db_path="unused.json", db_mode="no_save")
+    entry = db.add("Carol", [1.0], "img", 0.9)
+    db.remove(entry["id"])
+    assert db.get_by_id(entry["id"]) is None
+
+
+# Hybrid: filter get_all by name
+
+def test_get_all_by_name():
+    db = FaceprintsDatabase(db_path="unused.json", db_mode="no_save")
+    db.add("Dave", [1.0], "img", 0.9)
+    db.add("Eve", [2.0], "img", 0.8)
+    results = db.get_all("Eve")
+    assert len(results) == 1
+    assert results[0]["name"] == "Eve"

--- a/ros2_ws/src/ros2web/ros2web/tests/test_chunk_manager.py
+++ b/ros2_ws/src/ros2web/ros2web/tests/test_chunk_manager.py
@@ -1,0 +1,24 @@
+from ros2web.chunk_manager import ChunkManager
+
+# Black-box: verify messages are fragmented correctly
+
+def test_msg_to_chunks_basic():
+    manager = ChunkManager(max_chunk_size=4)
+    chunks = manager.msg_to_chunks("abcdef")
+    assert len(chunks) == 2
+    assert chunks[0].chunk_index == 0
+    assert chunks[0].final is False
+    assert chunks[1].chunk_index == 1
+    assert chunks[1].final is True
+
+
+# White-box: ensure chunks are reassembled and buffer cleared
+
+def test_chunk_to_msg_reassembles():
+    manager = ChunkManager(max_chunk_size=3)
+    msg_id = "1"
+    part = manager.chunk_to_msg(msg_id, 0, False, "abc")
+    assert part is None
+    final = manager.chunk_to_msg(msg_id, 1, True, "def")
+    assert final == "abcdef"
+    assert msg_id not in manager.buffers

--- a/ros2_ws/src/ros2web/ros2web/tests/test_websocket_server.py
+++ b/ros2_ws/src/ros2web/ros2web/tests/test_websocket_server.py
@@ -1,0 +1,53 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from ros2web.websocket_server import WebSocketServer
+
+
+class DummyWebSocket:
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.sent = []
+        self.remote_address = ("127.0.0.1", 1234)
+
+    async def send(self, msg):
+        self.sent.append(msg)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._messages:
+            return self._messages.pop(0)
+        raise StopAsyncIteration
+
+
+# Hybrid: handler should register client and process messages
+@pytest.mark.asyncio
+async def test_handler_processes_messages():
+    events = []
+    server = WebSocketServer(
+        on_message=lambda key, msg: events.append(("msg", key, msg)),
+        on_user_connect=lambda key: events.append(("connect", key)),
+        on_user_disconnect=lambda key: events.append(("disconnect", key)),
+    )
+
+    ws = DummyWebSocket(["hello"])
+    await server._handler(ws)
+
+    assert events == [
+        ("connect", "127.0.0.1:1234"),
+        ("msg", "127.0.0.1:1234", "hello"),
+        ("disconnect", "127.0.0.1:1234"),
+    ]
+    assert server.get_connection_count() == 0
+
+
+# White-box: _send_message sends via underlying websocket
+@pytest.mark.asyncio
+async def test_send_message():
+    server = WebSocketServer(None, None, None)
+    client = AsyncMock()
+    await server._send_message(client, "data")
+    client.send.assert_called_once_with("data")

--- a/ros2_ws/src/rumi_web/rumi_web/tests/test_session_manager.py
+++ b/ros2_ws/src/rumi_web/rumi_web/tests/test_session_manager.py
@@ -1,0 +1,26 @@
+import datetime
+from unittest.mock import Mock, patch
+
+from rumi_web.database.session_manager import SessionManager
+
+
+# Hybrid: verify detections are aggregated based on time_between_detections
+
+def test_process_detection_time_filter():
+    db = Mock()
+    times = iter([0, 0.5, 1.5])
+
+    class FakeDatetime(datetime.datetime):
+        @classmethod
+        def now(cls):
+            return datetime.datetime.fromtimestamp(next(times))
+
+    manager = SessionManager(db, timeout_seconds=5, time_between_detections=1)
+
+    with patch('rumi_web.database.session_manager.datetime', FakeDatetime):
+        manager.process_detection('1', 0.8, 0.9)
+        manager.process_detection('1', 0.8, 0.9)  # within 1s, ignored
+        manager.process_detection('1', 0.8, 0.9)  # after 1s, stored
+
+    session = manager.active_sessions['1']
+    assert len(session['detections']) == 2

--- a/ros2_ws/src/sancho_ai/sancho_ai/tests/test_modular_ai.py
+++ b/ros2_ws/src/sancho_ai/sancho_ai/tests/test_modular_ai.py
@@ -1,0 +1,49 @@
+from unittest.mock import Mock
+
+from sancho_ai.ais.base.modular_ai import ModularAI
+from sancho_ai.prompts.commands.commands import COMMANDS
+
+
+class DummyModularAI(ModularAI):
+    pass
+
+
+# Hybrid: pipeline when intent recognized
+
+def test_modular_ai_pipeline_known_intent():
+    classifier = Mock()
+    executor = Mock()
+    generator = Mock()
+
+    classifier.classify.return_value = (COMMANDS.TAKE_PICTURE, {"foo": 1}, "prov", "model")
+    executor.execute.return_value = ("details", "ok", {"data": 42})
+    generator.generate_response.return_value = ("done", "happy", "gprov", "gmodel")
+
+    ai = DummyModularAI(classifier, executor, generator)
+    value, intent, args, prov, model = ai.on_message("hi", ["h"])
+
+    classifier.classify.assert_called_once_with("hi", ["h"])
+    executor.execute.assert_called_once_with(COMMANDS.TAKE_PICTURE, {"foo": 1})
+    generator.generate_response.assert_called_once()
+    assert value == {"text": "done", "emotion": "happy", "data": {"data": 42}}
+    assert prov == "gprov" and model == "gmodel"
+    assert intent == COMMANDS.TAKE_PICTURE and args == {"foo": 1}
+
+
+# Hybrid: pipeline when intent is unknown
+
+def test_modular_ai_pipeline_unknown_intent():
+    classifier = Mock()
+    executor = Mock()
+    generator = Mock()
+
+    classifier.classify.return_value = (COMMANDS.UNKNOWN, {}, "prov", "model")
+    generator.continue_conversation.return_value = ("ok", "neutral", "gprov", "gmodel")
+
+    ai = DummyModularAI(classifier, executor, generator)
+    value, intent, args, prov, model = ai.on_message("hello")
+
+    executor.execute.assert_not_called()
+    generator.continue_conversation.assert_called_once()
+    assert intent == COMMANDS.UNKNOWN
+    assert value["text"] == "ok"


### PR DESCRIPTION
## Summary
- add STTHotword tests in `hri_audio`
- create FaceprintsDatabase unit tests in `hri_vision`
- test ChunkManager and WebSocketServer logic in `ros2web`
- add session manager test in `rumi_web`
- cover ModularAI pipeline in `sancho_ai`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other import issues)*

------
https://chatgpt.com/codex/tasks/task_e_684e01c70090832f91cfa35591198ad3